### PR TITLE
Improve domain validation

### DIFF
--- a/helpers/ValidateHelper.php
+++ b/helpers/ValidateHelper.php
@@ -392,7 +392,7 @@ class ValidateHelper extends \Validate
     public static function isDomain($domain)
     {
         if (static::isAscii($domain) && false !== strpos($domain, '.') && false === static::isPunycodeDomain($domain)) {
-            if (1 === preg_match('/^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,63}$/', $domain)) {
+            if (1 === preg_match('/^(?!.{254,})(?:(?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)*(?!-)(?![0-9]*$)[A-Za-z0-9-]{1,63}(?<!-)$/', $domain)) {
                 return true;
             }
         }


### PR DESCRIPTION
Following informations provided at https://en.wikipedia.org/wiki/Domain_Name_System#cite_ref-rfc3696_28-0
* domain name can't be exceed  253 caracters
* maximum label are 127
* last label can't (should not) be all numeric
* ignore before last label capturing group